### PR TITLE
Update popupLight page

### DIFF
--- a/appdaemon/apps/nspanel.py
+++ b/appdaemon/apps/nspanel.py
@@ -115,11 +115,18 @@ class NsPanelLovelanceUI:
           entity = self.api.get_entity(msg[3])
           switch_val = 1 if entity.state == "on" else 0
           # scale 0-255 brightness from ha to 0-100
-          brightness = int(self.scale(entity.attributes.brightness,(0,255),(0,100)))
-          if "color_temp" in entity.attributes.supported_color_modes:
-            # scale ha color temp range to 0-100
-            color_temp = self.scale(entity.attributes.color_temp,(entity.attributes.min_mireds, entity.attributes.max_mireds),(0,100))
+          if entity.state == "on":
+            if entity.attributes.get("brightness"):
+              brightness = int(self.scale(entity.attributes.brightness,(0,255),(0,100)))
+            else:
+              brightness = 255 # light can't be dimmed so show brightness as 100%
+            if "color_temp" in entity.attributes.supported_color_modes:
+              # scale ha color temp range to 0-100
+              color_temp = self.scale(entity.attributes.color_temp,(entity.attributes.min_mireds, entity.attributes.max_mireds),(0,100))
+            else:
+              color_temp = "disable"
           else:
+            brightness = 0
             color_temp = "disable"
           self.send_mqtt_msg("entityUpdateDetail,{0},{1},{2}".format(switch_val,brightness,color_temp))
 


### PR DESCRIPTION
* When the light is off there is no attribute brightness, so in that case show brightness as 0.
* There are also lights with no brightness, in that case show brightness as 100% -> maybe cleaner to not show the popupLight page for these lights?
* Show color temp range slider only if light is on as attribute `color_temp` is only available when light is on.

To do: refresh popupPage when light is turned on/off so brightness and color temp are updated.